### PR TITLE
Smart security code hint detection according to the payment card brand

### DIFF
--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/util/extension/VGSCardNumberEditText.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/util/extension/VGSCardNumberEditText.kt
@@ -1,0 +1,7 @@
+package com.verygoodsecurity.vgscheckout.util.extension
+
+import com.verygoodsecurity.vgscollect.view.card.CardType
+import com.verygoodsecurity.vgscollect.widget.VGSCardNumberEditText
+
+internal fun VGSCardNumberEditText.isAmericanExpress() =
+    getState()?.cardBrand == CardType.AMERICAN_EXPRESS.name

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/util/extension/View.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/util/extension/View.kt
@@ -4,6 +4,10 @@ import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.StateListDrawable
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
 
 internal fun View.applyStokeColor(width: Int, color: Int) {
     if (background is StateListDrawable) {
@@ -23,3 +27,9 @@ internal fun ViewGroup.disable() {
         }
     }
 }
+
+internal fun View.getString(@StringRes id: Int) = resources.getString(id)
+
+internal fun View.getDrawable(@DrawableRes id: Int) = ContextCompat.getDrawable(context, id)
+
+internal fun View.getColor(@ColorRes id: Int) = ContextCompat.getColor(context, id)

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/view/CheckoutView.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/view/CheckoutView.kt
@@ -7,13 +7,10 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContextCompat
 import com.google.android.material.button.MaterialButton
 import com.verygoodsecurity.vgscheckout.R
 import com.verygoodsecurity.vgscheckout.config.ui.VGSCheckoutVaultFormConfiguration
-import com.verygoodsecurity.vgscheckout.util.extension.applyStokeColor
-import com.verygoodsecurity.vgscheckout.util.extension.disable
-import com.verygoodsecurity.vgscheckout.util.extension.toCollectCardBrand
+import com.verygoodsecurity.vgscheckout.util.extension.*
 import com.verygoodsecurity.vgscollect.core.VGSCollect
 import com.verygoodsecurity.vgscollect.core.model.state.FieldState
 import com.verygoodsecurity.vgscollect.core.model.state.FieldState.CardHolderNameState
@@ -48,15 +45,9 @@ class CheckoutView @JvmOverloads constructor(
     internal var onPayListener: OnPayClickListener? = null
 
     // Stroke colors
-    private val defaultStrokeColor by lazy {
-        ContextCompat.getColor(context, R.color.vgs_checkout_stroke_default)
-    }
-    private val highlightedStrokeColor by lazy {
-        ContextCompat.getColor(context, R.color.vgs_checkout_stroke_highlighted)
-    }
-    private val errorStrokeColor by lazy {
-        ContextCompat.getColor(context, R.color.vgs_checkout_stroke_error)
-    }
+    private val defaultStrokeColor by lazy { getColor(R.color.vgs_checkout_stroke_default) }
+    private val highlightedStrokeColor by lazy { getColor(R.color.vgs_checkout_stroke_highlighted) }
+    private val errorStrokeColor by lazy { getColor(R.color.vgs_checkout_stroke_error) }
 
     init {
         inflate(context, R.layout.checkout_layout, this)
@@ -108,9 +99,8 @@ class CheckoutView @JvmOverloads constructor(
     private fun handlePayClicked() {
         cardHolderLL.disable()
         cardDetailsCL.disable()
-        payMB.text = resources.getString(R.string.vgs_checkout_pay_button_processing_title)
-        payMB.icon =
-            ContextCompat.getDrawable(context, R.drawable.animated_ic_progress_circle_white_16dp)
+        payMB.text = getString(R.string.vgs_checkout_pay_button_processing_title)
+        payMB.icon = getDrawable(R.drawable.animated_ic_progress_circle_white_16dp)
         (payMB.icon as Animatable).start()
         onPayListener?.onPayClicked()
     }
@@ -121,6 +111,7 @@ class CheckoutView @JvmOverloads constructor(
 
     private fun handleCardDetailsStateChanged() {
         updateCardDetailsBorderColor()
+        updateSecurityCodeHint()
         // TODO: Handle error message
     }
 
@@ -130,6 +121,18 @@ class CheckoutView @JvmOverloads constructor(
             dividerHorizontal.setBackgroundColor(this)
             dividerVertical.setBackgroundColor(this)
         }
+    }
+
+    private fun updateSecurityCodeHint() {
+        cvcEt.setHint(
+            getString(
+                if (cardNumberEt.isAmericanExpress()) {
+                    R.string.vgs_checkout_card_cvv_hint
+                } else {
+                    R.string.vgs_checkout_card_cvc_hint
+                }
+            )
+        )
     }
 
     private fun updatePayButtonState() {

--- a/vgscheckout/src/main/res/values/strings.xml
+++ b/vgscheckout/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 
     <string name="vgs_checkout_card_cvc_subtitle">Security code</string>
     <string name="vgs_checkout_card_cvc_hint">CVC</string>
+    <string name="vgs_checkout_card_cvv_hint">CVV</string>
     <string name="vgs_checkout_card_cvc_error">Enter a valid card verification code</string>
 
     <string name="vgs_checkout_pay_button_title">Pay</string>


### PR DESCRIPTION
## Feature [ANDROIDSDK-401](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-401)

## Description of changes
Check current card brand and set "CVV" hint if the brand is American Express.(Same logic as Stripe)
