### PR TITLE
Add Ability to hide card number/cvc icon

### DIFF
--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/widget/CardVerificationCodeEditText.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/widget/CardVerificationCodeEditText.kt
@@ -108,4 +108,8 @@ internal class CardVerificationCodeEditText @JvmOverloads constructor(
     fun setPreviewIconAdapter(adapter: CVCIconAdapter?) {
         setCVCPreviewIconAdapter(adapter)
     }
+
+    fun setPreviewIconMode(mode: CVCInputField.PreviewIconVisibility) {
+        applyPreviewIconMode(mode.ordinal)
+    }
 }

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/widget/VGSCardNumberEditText.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/widget/VGSCardNumberEditText.kt
@@ -7,16 +7,17 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.inputmethod.EditorInfo
 import com.verygoodsecurity.vgscheckout.R
-import com.verygoodsecurity.vgscheckout.collect.core.model.state.FieldState
 import com.verygoodsecurity.vgscheckout.collect.VGSCollectLogger
+import com.verygoodsecurity.vgscheckout.collect.core.model.state.FieldState
 import com.verygoodsecurity.vgscheckout.collect.view.InputFieldView
 import com.verygoodsecurity.vgscheckout.collect.view.card.BrandParams
 import com.verygoodsecurity.vgscheckout.collect.view.card.CardBrand
 import com.verygoodsecurity.vgscheckout.collect.view.card.FieldType
-import com.verygoodsecurity.vgscheckout.collect.view.card.validation.rules.PaymentCardNumberRule
 import com.verygoodsecurity.vgscheckout.collect.view.card.formatter.CardMaskAdapter
 import com.verygoodsecurity.vgscheckout.collect.view.card.icon.CardIconAdapter
 import com.verygoodsecurity.vgscheckout.collect.view.card.validation.payment.ChecksumAlgorithm
+import com.verygoodsecurity.vgscheckout.collect.view.card.validation.rules.PaymentCardNumberRule
+import com.verygoodsecurity.vgscheckout.collect.view.internal.CardInputField
 
 /**
  * A user interface element that displays text to the user in bank card number format.
@@ -142,6 +143,10 @@ internal class VGSCardNumberEditText @JvmOverloads constructor(
      */
     fun getCardPreviewIconGravity(): Int {
         return getCardIconGravity()
+    }
+
+    fun setCardBrandPreviewIconMode(mode: CardInputField.PreviewIconMode) {
+        applyPreviewIconMode(mode.ordinal)
     }
 
     /**

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/ui/view/card/cardnumber/VGSCheckoutCardNumberOptions.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/ui/view/card/cardnumber/VGSCheckoutCardNumberOptions.kt
@@ -9,16 +9,22 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 class VGSCheckoutCardNumberOptions private constructor(
     override val fieldName: String,
+    val isIconHidden: Boolean,
     val cardBrands: Set<VGSCheckoutCardBrand>
 ) : ViewOptions() {
 
     class Builder {
 
         private var fieldName: String = ""
+        private var isIconHidden: Boolean = false
         private var cardBrands: Set<VGSCheckoutCardBrand> = VGSCheckoutCardBrand.BRANDS
 
         fun setFieldName(fieldName: String) = this.apply {
             this.fieldName = fieldName
+        }
+
+        fun setIconHidden(isHidden: Boolean) = this.apply {
+            this.isIconHidden = isHidden
         }
 
         fun setCardBrands(
@@ -31,6 +37,6 @@ class VGSCheckoutCardNumberOptions private constructor(
             }
         }
 
-        fun build() = VGSCheckoutCardNumberOptions(fieldName, cardBrands)
+        fun build() = VGSCheckoutCardNumberOptions(fieldName, isIconHidden, cardBrands)
     }
 }

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/ui/view/card/cvc/VGSCheckoutCVCOptions.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/ui/view/card/cvc/VGSCheckoutCVCOptions.kt
@@ -4,16 +4,24 @@ import com.verygoodsecurity.vgscheckout.config.ui.view.core.ViewOptions
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class VGSCheckoutCVCOptions private constructor(override val fieldName: String) : ViewOptions() {
+class VGSCheckoutCVCOptions private constructor(
+    override val fieldName: String,
+    val isIconHidden: Boolean
+) : ViewOptions() {
 
     class Builder {
 
         private var fieldName: String = ""
+        private var isIconHidden: Boolean = false
 
         fun setFieldName(fieldName: String) = this.apply {
             this.fieldName = fieldName
         }
 
-        fun build() = VGSCheckoutCVCOptions(fieldName)
+        fun setIconHidden(isHidden: Boolean) = this.apply {
+            this.isIconHidden = isHidden
+        }
+
+        fun build() = VGSCheckoutCVCOptions(fieldName, isIconHidden)
     }
 }

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/view/checkout/card/CreditCardView.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/view/checkout/card/CreditCardView.kt
@@ -10,6 +10,8 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import com.google.android.material.textview.MaterialTextView
 import com.verygoodsecurity.vgscheckout.R
 import com.verygoodsecurity.vgscheckout.collect.core.model.state.FieldState.*
+import com.verygoodsecurity.vgscheckout.collect.view.internal.CVCInputField
+import com.verygoodsecurity.vgscheckout.collect.view.internal.CardInputField
 import com.verygoodsecurity.vgscheckout.collect.widget.CardVerificationCodeEditText
 import com.verygoodsecurity.vgscheckout.collect.widget.ExpirationDateEditText
 import com.verygoodsecurity.vgscheckout.collect.widget.PersonNameEditText
@@ -23,8 +25,8 @@ import com.verygoodsecurity.vgscheckout.util.ObservableLinkedHashMap
 import com.verygoodsecurity.vgscheckout.util.extension.*
 import com.verygoodsecurity.vgscheckout.view.checkout.card.adapter.CardIconAdapter
 import com.verygoodsecurity.vgscheckout.view.checkout.card.adapter.CardMaskAdapter
-import com.verygoodsecurity.vgscheckout.view.checkout.core.model.InputViewStateHolder
 import com.verygoodsecurity.vgscheckout.view.checkout.core.OnStateChangeListener
+import com.verygoodsecurity.vgscheckout.view.checkout.core.model.InputViewStateHolder
 import com.verygoodsecurity.vgscheckout.view.checkout.core.model.StateChangeListener
 import com.verygoodsecurity.vgscheckout.view.checkout.core.model.ViewState
 
@@ -161,6 +163,13 @@ internal class CreditCardView @JvmOverloads internal constructor(
 
     private fun applyCardNumberOptions(options: VGSCheckoutCardNumberOptions) {
         etCardNumber.setFieldName(options.fieldName)
+        etCardNumber.setCardBrandPreviewIconMode(
+            if (options.isIconHidden) {
+                CardInputField.PreviewIconMode.NEVER
+            } else {
+                CardInputField.PreviewIconMode.ALWAYS
+            }
+        )
         etCardNumber.setValidCardBrands(*options.cardBrands.map { it.toCollectCardBrand() }
             .toTypedArray())
         etCardNumber.setCardMaskAdapter(CardMaskAdapter(options.cardBrands))
@@ -178,6 +187,13 @@ internal class CreditCardView @JvmOverloads internal constructor(
 
     private fun applySecurityCodeOptions(options: VGSCheckoutCVCOptions) {
         etSecurityCode.setFieldName(options.fieldName)
+        etSecurityCode.setPreviewIconMode(
+            if (options.isIconHidden) {
+                CVCInputField.PreviewIconVisibility.NEVER
+            } else {
+                CVCInputField.PreviewIconVisibility.ALWAYS
+            }
+        )
     }
 
     private fun handleCardHolderStateChanged(state: ViewState) {


### PR DESCRIPTION
## Feature [ANDROIDSDK-445](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-445)

## Description of changes
 - Add `isIconHidden` attribute to `VGSCheckoutCardNumberOptions/VGSCheckoutCVCOptions`.
 - Add `setIconHidden` function to `VGSCheckoutCardNumberOptions.Builder/VGSCheckoutCVCOptions.Builder`.
