### PR TITLE
Refactor id property’s names

### DIFF
--- a/custom-example/src/main/java/com/verygoodsecurity/custom/example/MainActivity.kt
+++ b/custom-example/src/main/java/com/verygoodsecurity/custom/example/MainActivity.kt
@@ -41,7 +41,7 @@ class MainActivity : AppCompatActivity(), VGSCheckoutCallback {
 
     //region Checkout config
     private fun getCheckoutConfig() = VGSCheckoutCustomConfig(
-        vaultID = vaultId,
+        vaultId = vaultId,
         routeConfig = getCheckoutRouteConfig(),
         formConfig = getCheckoutFormConfig()
     )

--- a/multiplexing-example/build.gradle
+++ b/multiplexing-example/build.gradle
@@ -44,8 +44,8 @@ android {
     }
 
     applicationVariants.all { variant ->
-        String vaultId = getLocalProperty("VGS_VAULT_ID")
-        variant.resValue "string", "vault_id", vaultId + ''
+        String tenantId = getLocalProperty("VGS_VAULT_ID")
+        variant.resValue "string", "tenant_id", tenantId + ''
     }
 }
 

--- a/multiplexing-example/src/main/java/com/verygoodsecurity/multiplexing/example/MainActivity.kt
+++ b/multiplexing-example/src/main/java/com/verygoodsecurity/multiplexing/example/MainActivity.kt
@@ -16,7 +16,7 @@ import com.verygoodsecurity.vgscheckout.model.VGSCheckoutResult
 
 class MainActivity : AppCompatActivity(), VGSCheckoutCallback {
 
-    private val vaultId: String by lazy { getString(R.string.vault_id) }
+    private val tenantId: String by lazy { getString(R.string.tenant_id) }
 
     private val applicationClient: HttpClient by lazy {
         HttpClient()
@@ -51,7 +51,7 @@ class MainActivity : AppCompatActivity(), VGSCheckoutCallback {
 
     private fun getCheckoutConfig() = VGSCheckoutMultiplexingConfig(
         accessToken = accessToken,
-        vaultID = vaultId
+        tenantId = tenantId
     )
 
     override fun onCheckoutResult(result: VGSCheckoutResult) {
@@ -69,12 +69,12 @@ class MainActivity : AppCompatActivity(), VGSCheckoutCallback {
             arguments = when (result) {
                 is VGSCheckoutResult.Success -> Bundle().apply {
                     result.code?.let { putInt(TransactionDialogFragment.CODE, it) }
-                    putString(TransactionDialogFragment.TNT, vaultId)
+                    putString(TransactionDialogFragment.TNT, tenantId)
                     putString(TransactionDialogFragment.BODY, result.body)
                 }
                 is VGSCheckoutResult.Failed -> Bundle().apply {
                     result.code?.let { putInt(TransactionDialogFragment.CODE, it) }
-                    putString(TransactionDialogFragment.TNT, vaultId)
+                    putString(TransactionDialogFragment.TNT, tenantId)
                     putString(TransactionDialogFragment.BODY, result.body)
                 }
                 is VGSCheckoutResult.Canceled -> Bundle()

--- a/vgscheckout/src/androidTest/java/com/verygoodsecurity/vgscheckout/custom/integration/CustomActivityResultTest.kt
+++ b/vgscheckout/src/androidTest/java/com/verygoodsecurity/vgscheckout/custom/integration/CustomActivityResultTest.kt
@@ -89,7 +89,7 @@ class CustomActivityResultTest {
                 EXTRA_KEY_ARGS,
                 CheckoutResultContract.Args(
                     VGSCheckoutCustomConfig(
-                        vaultID = BuildConfig.VAULT_ID,
+                        vaultId = BuildConfig.VAULT_ID,
                         VGSCheckoutEnvironment.Sandbox(),
                         VGSCheckoutCustomRouteConfig("/post"),
                         VGSCheckoutCustomFormConfig(

--- a/vgscheckout/src/androidTest/java/com/verygoodsecurity/vgscheckout/custom/ui/HideComponentTest.kt
+++ b/vgscheckout/src/androidTest/java/com/verygoodsecurity/vgscheckout/custom/ui/HideComponentTest.kt
@@ -37,7 +37,7 @@ class HideComponentTest {
                 EXTRA_KEY_ARGS,
                 CheckoutResultContract.Args(
                     VGSCheckoutCustomConfig(
-                        vaultID = BuildConfig.VAULT_ID,
+                        vaultId = BuildConfig.VAULT_ID,
                         formConfig = VGSCheckoutCustomFormConfig(
                             cardOptions = VGSCheckoutCustomCardOptions(
                                 cardHolderOptions = VGSCheckoutCustomCardHolderOptions(
@@ -64,7 +64,7 @@ class HideComponentTest {
                 EXTRA_KEY_ARGS,
                 CheckoutResultContract.Args(
                     VGSCheckoutCustomConfig(
-                        vaultID = BuildConfig.VAULT_ID,
+                        vaultId = BuildConfig.VAULT_ID,
                         formConfig = VGSCheckoutCustomFormConfig(
                             addressOptions =
                             VGSCheckoutCustomBillingAddressOptions(

--- a/vgscheckout/src/androidTest/java/com/verygoodsecurity/vgscheckout/custom/ui/OnFocusFieldsValidationTest.kt
+++ b/vgscheckout/src/androidTest/java/com/verygoodsecurity/vgscheckout/custom/ui/OnFocusFieldsValidationTest.kt
@@ -46,7 +46,7 @@ class OnFocusFieldsValidationTest {
         putExtra(
             EXTRA_KEY_ARGS,
             CheckoutResultContract.Args(VGSCheckoutCustomConfig(
-                vaultID = BuildConfig.VAULT_ID,
+                vaultId = BuildConfig.VAULT_ID,
                 formConfig = VGSCheckoutCustomFormConfig(
                     addressOptions = VGSCheckoutCustomBillingAddressOptions(
                         visibility = VGSCheckoutBillingAddressVisibility.VISIBLE

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/VGSCheckout.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/VGSCheckout.kt
@@ -61,7 +61,7 @@ class VGSCheckout internal constructor(
      * Start checkout with multiplexing configuration.
      *
      * @param accessToken client backend access token.
-     * @param vaultID VGS vault id.
+     * @param tenantId payment orchestration tenant id.
      * @param environment type of vault to communicate with.
      * @param transitionOptions specifying a custom animation to run when the checkout is displayed.
      * @param isAnalyticsEnabled true if checkout should send analytics events, false otherwise.
@@ -74,7 +74,7 @@ class VGSCheckout internal constructor(
     @Throws(VGSCheckoutJWTParseException::class, VGSCheckoutJWTRestrictedRoleException::class)
     fun present(
         accessToken: String,
-        vaultID: String,
+        tenantId: String,
         environment: VGSCheckoutEnvironment = VGSCheckoutEnvironment.Sandbox(),
         transitionOptions: VGSCheckoutTransitionOptions? = null,
         isAnalyticsEnabled: Boolean = true
@@ -82,7 +82,7 @@ class VGSCheckout internal constructor(
         present(
             VGSCheckoutMultiplexingConfig(
                 accessToken,
-                vaultID,
+                tenantId,
                 environment,
                 isAnalyticsEnabled = isAnalyticsEnabled
             ),

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/DefaultAnalyticsTracker.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/DefaultAnalyticsTracker.kt
@@ -12,18 +12,18 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 internal class DefaultAnalyticsTracker @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) constructor(
-    private val vaultID: String,
+    private val id: String,
     private val environment: String,
-    private val formID: String,
+    private val formId: String,
     private val client: ApiClient
 ) : AnalyticTracker {
 
     override var isEnabled: Boolean = true
 
-    constructor(vaultID: String, environment: String, formID: String) : this(
-        vaultID,
+    constructor(id: String, environment: String, formId: String) : this(
+        id,
         environment,
-        formID,
+        formId,
         ApiClient.create(false, getExecutor())
     )
 
@@ -31,7 +31,7 @@ internal class DefaultAnalyticsTracker @VisibleForTesting(otherwise = VisibleFor
         if (isEnabled.not()) {
             return
         }
-        val payload = event.getData(vaultID, formID, environment).toJSON().toString().toBase64()
+        val payload = event.getData(id, formId, environment).toJSON().toString().toBase64()
         client.enqueue(
             NetworkRequest(
                 method = HTTPMethod.POST,

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/event/core/Event.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/event/core/Event.kt
@@ -28,10 +28,10 @@ internal abstract class Event constructor(type: String) {
     )
         get() = field + attributes
 
-    fun getData(vaultID: String, formID: String, environment: String): Map<String, Any> {
+    fun getData(id: String, formId: String, environment: String): Map<String, Any> {
         return data.apply {
-            put(KEY_VAULT_ID, vaultID)
-            put(KEY_FORM_ID, formID)
+            put(KEY_ID, id)
+            put(KEY_FORM_ID, formId)
             put(KEY_ENVIRONMENT, environment)
         }
     }
@@ -59,7 +59,7 @@ internal abstract class Event constructor(type: String) {
         private const val KEY_DEVICE = "device"
         private const val KEY_DEVICE_MODEL = "deviceModel"
         private const val KEY_OS = "osVersion"
-        private const val KEY_VAULT_ID = "tnt"
+        private const val KEY_ID = "tnt"
         private const val KEY_FORM_ID = "formId"
         private const val KEY_ENVIRONMENT = "env"
 

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutCustomConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutCustomConfig.kt
@@ -19,10 +19,10 @@ import kotlinx.parcelize.Parcelize
  */
 @Parcelize
 class VGSCheckoutCustomConfig @JvmOverloads constructor(
-    override val vaultID: String,
+    val vaultID: String,
     override val environment: VGSCheckoutEnvironment = VGSCheckoutEnvironment.Sandbox(),
     override val routeConfig: VGSCheckoutCustomRouteConfig = VGSCheckoutCustomRouteConfig(),
     override val formConfig: VGSCheckoutCustomFormConfig = VGSCheckoutCustomFormConfig(),
     override val isScreenshotsAllowed: Boolean = false,
     override val isAnalyticsEnabled: Boolean = true,
-) : CheckoutConfig()
+) : CheckoutConfig(vaultID)

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutCustomConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutCustomConfig.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
 /**
  * Holds configuration for vault payment processing with custom configuration.
  *
- * @param vaultID unique organization vault id.
+ * @param vaultId unique organization vault id.
  * @param environment type of vault.
  * @param routeConfig Networking configuration, like http method, request headers etc.
  * @param formConfig UI configuration.
@@ -19,10 +19,10 @@ import kotlinx.parcelize.Parcelize
  */
 @Parcelize
 class VGSCheckoutCustomConfig @JvmOverloads constructor(
-    val vaultID: String,
+    val vaultId: String,
     override val environment: VGSCheckoutEnvironment = VGSCheckoutEnvironment.Sandbox(),
     override val routeConfig: VGSCheckoutCustomRouteConfig = VGSCheckoutCustomRouteConfig(),
     override val formConfig: VGSCheckoutCustomFormConfig = VGSCheckoutCustomFormConfig(),
     override val isScreenshotsAllowed: Boolean = false,
     override val isAnalyticsEnabled: Boolean = true,
-) : CheckoutConfig(vaultID)
+) : CheckoutConfig(vaultId)

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutMultiplexingConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutMultiplexingConfig.kt
@@ -14,7 +14,7 @@ import com.verygoodsecurity.vgscheckout.model.VGSCheckoutEnvironment
  * Holds configuration with predefined setup for work with payment orchestration/multiplexing app.
  *
  * @param accessToken multiplexing app access token.
- * @param vaultID unique organization vault id.
+ * @param tenantId payment orchestration tenant id.
  * @param environment type of vault.
  * @param routeConfig Networking configuration, like http method, request headers etc.
  * @param formConfig UI configuration.
@@ -26,14 +26,14 @@ import com.verygoodsecurity.vgscheckout.model.VGSCheckoutEnvironment
 @Suppress("MemberVisibilityCanBePrivate", "CanBeParameter")
 class VGSCheckoutMultiplexingConfig private constructor(
     internal val accessToken: String,
-    override val vaultID: String,
+    val tenantId: String,
     override val environment: VGSCheckoutEnvironment,
     override val routeConfig: VGSCheckoutMultiplexingRouteConfig,
     override val formConfig: VGSCheckoutMultiplexingFormConfig,
     override val isScreenshotsAllowed: Boolean,
     override val isAnalyticsEnabled: Boolean,
     private val createdFromParcel: Boolean
-) : CheckoutConfig() {
+) : CheckoutConfig(tenantId) {
 
     init {
         if (!createdFromParcel) validateToken()
@@ -54,7 +54,7 @@ class VGSCheckoutMultiplexingConfig private constructor(
      * Public constructor.
      *
      * @param accessToken multiplexing app access token.
-     * @param vaultID unique organization vault id.
+     * @param tenantId payment orchestration tenant id.
      * @param environment type of vault.
      * @param formConfig UI configuration.
      * @param isScreenshotsAllowed If true, checkout form will allow to make screenshots. Default is false.
@@ -69,14 +69,14 @@ class VGSCheckoutMultiplexingConfig private constructor(
     @Throws(VGSCheckoutJWTParseException::class, VGSCheckoutJWTRestrictedRoleException::class)
     constructor(
         accessToken: String,
-        vaultID: String,
+        tenantId: String,
         environment: VGSCheckoutEnvironment = VGSCheckoutEnvironment.Sandbox(),
         formConfig: VGSCheckoutMultiplexingFormConfig = VGSCheckoutMultiplexingFormConfig(),
         isScreenshotsAllowed: Boolean = false,
         isAnalyticsEnabled: Boolean = true
     ) : this(
         accessToken,
-        vaultID,
+        tenantId,
         environment,
         VGSCheckoutMultiplexingRouteConfig(accessToken),
         formConfig,
@@ -87,7 +87,7 @@ class VGSCheckoutMultiplexingConfig private constructor(
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeString(accessToken)
-        parcel.writeString(vaultID)
+        parcel.writeString(tenantId)
         parcel.writeParcelable(environment, flags)
         parcel.writeParcelable(routeConfig, flags)
         parcel.writeParcelable(formConfig, flags)

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/core/CheckoutConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/core/CheckoutConfig.kt
@@ -10,13 +10,10 @@ import java.util.*
 
 /**
  * Base class of checkout config.
+ *
+ * @property id unique organization vault id.
  */
-abstract class CheckoutConfig internal constructor() : Parcelable {
-
-    /**
-     * Unique organization vault id.
-     */
-    abstract val vaultID: String
+abstract class CheckoutConfig internal constructor(val id: String) : Parcelable {
 
     /**
      * Type of vault.
@@ -46,7 +43,7 @@ abstract class CheckoutConfig internal constructor() : Parcelable {
     abstract val isAnalyticsEnabled: Boolean
 
     internal val analyticTracker: AnalyticTracker by lazy {
-        DefaultAnalyticsTracker(vaultID, environment.value, UUID.randomUUID().toString()).apply {
+        DefaultAnalyticsTracker(id, environment.value, UUID.randomUUID().toString()).apply {
             isEnabled = isAnalyticsEnabled
         }
     }

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/core/CheckoutConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/core/CheckoutConfig.kt
@@ -13,7 +13,7 @@ import java.util.*
  *
  * @property id unique organization vault id.
  */
-abstract class CheckoutConfig internal constructor(val id: String) : Parcelable {
+abstract class CheckoutConfig internal constructor(internal val id: String) : Parcelable {
 
     /**
      * Type of vault.

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/util/CollectProvider.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/util/CollectProvider.kt
@@ -14,7 +14,7 @@ internal class CollectProvider {
         context: Context,
         config: CheckoutConfig
     ): VGSCollect {
-        return VGSCollect.Builder(context, config.vaultID)
+        return VGSCollect.Builder(context, config.id)
             .setEnvironment(config.environment.value)
             .setAnalyticTracker(config.analyticTracker)
             .applyHostnamePolicy(config.routeConfig.hostnamePolicy)

--- a/vgscheckout/src/test/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/DefaultAnalyticsTrackerTest.kt
+++ b/vgscheckout/src/test/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/DefaultAnalyticsTrackerTest.kt
@@ -14,7 +14,7 @@ import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.*
 
-private const val VAULT_ID = "test_vault_id"
+private const val ID = "test_vault_id"
 private const val FORM_ID = "test_form_id"
 private const val ENVIRONMENT = "test_env"
 
@@ -22,7 +22,7 @@ class DefaultAnalyticsTrackerTest {
 
     private val mockApiClient: ApiClient = mock(OkHttpClient::class.java)
     private val callback: (NetworkResponse) -> Unit = {}
-    private var tracker = DefaultAnalyticsTracker(VAULT_ID, ENVIRONMENT, FORM_ID, mockApiClient)
+    private var tracker = DefaultAnalyticsTracker(ID, ENVIRONMENT, FORM_ID, mockApiClient)
 
     @Test
     fun log_analyticsEnabled_apiClientCalled() {
@@ -63,7 +63,7 @@ class DefaultAnalyticsTrackerTest {
     fun log_apiCalledWithCorrectData() {
         // Arrange
         val event = InitEvent(InitEvent.ConfigType.CUSTOM)
-        val payload = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT).toJSON().toString().toBase64()
+        val payload = event.getData(ID, FORM_ID, ENVIRONMENT).toJSON().toString().toBase64()
         val expectedNetworkRequest = NetworkRequest(
             method = HTTPMethod.POST,
             url = "https://vgs-collect-keeper.apps.verygood.systems/vgs",

--- a/vgscheckout/src/test/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/event/core/EventsTest.kt
+++ b/vgscheckout/src/test/java/com/verygoodsecurity/vgscheckout/collect/core/api/analityc/event/core/EventsTest.kt
@@ -5,7 +5,7 @@ import com.verygoodsecurity.vgscheckout.config.networking.request.core.VGSChecko
 import org.junit.Assert.*
 import org.junit.Test
 
-private const val VAULT_ID = "test_vault_id"
+private const val ID = "test_vault_id"
 private const val FORM_ID = "test_form_id"
 private const val ENVIRONMENT = "test_env"
 
@@ -21,7 +21,7 @@ class EventsTest {
             override val attributes: Map<String, Any> = emptyMap()
         }
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertNotNull(data["status"])
         assertNotNull(data["type"])
@@ -44,10 +44,10 @@ class EventsTest {
             override val attributes: Map<String, Any> = emptyMap()
         }
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], TEST_TYPE)
-        assertEquals(data["tnt"], VAULT_ID)
+        assertEquals(data["tnt"], ID)
         assertEquals(data["formId"], FORM_ID)
         assertEquals(data["env"], ENVIRONMENT)
     }
@@ -60,7 +60,7 @@ class EventsTest {
             override val attributes: Map<String, Any> = emptyMap()
         }
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["status"], "Ok")
     }
@@ -74,7 +74,7 @@ class EventsTest {
             override val attributes: Map<String, Any> = mapOf("status" to testStatus)
         }
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["status"], testStatus)
     }
@@ -89,7 +89,7 @@ class EventsTest {
             override val attributes: Map<String, Any> = mapOf(testKey to testValue)
         }
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data[testKey], testValue)
     }
@@ -100,7 +100,7 @@ class EventsTest {
         val testFieldName = "test_field_name"
         val event = AutofillEvent(testFieldName)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Autofill")
         assertEquals(data["field"], testFieldName)
@@ -111,7 +111,7 @@ class EventsTest {
         // Arrange
         val event = CancelEvent
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Cancel")
     }
@@ -122,7 +122,7 @@ class EventsTest {
         val hostname = "test"
         val event = HostnameValidationEvent(true, hostname)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "HostNameValidation")
         assertEquals(data["hostname"], hostname)
@@ -135,7 +135,7 @@ class EventsTest {
         val hostname = "test"
         val event = HostnameValidationEvent(false, hostname)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "HostNameValidation")
         assertEquals(data["hostname"], hostname)
@@ -147,7 +147,7 @@ class EventsTest {
         // Arrange
         val event = InitEvent(InitEvent.ConfigType.CUSTOM)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Init")
         assertEquals(data["config"], "custom")
@@ -158,7 +158,7 @@ class EventsTest {
         // Arrange
         val event = InitEvent(InitEvent.ConfigType.MULTIPLEXING)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Init")
         assertEquals(data["config"], "multiplexing")
@@ -169,7 +169,7 @@ class EventsTest {
         // Arrange
         val event = JWTValidationEvent(true)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "JWTValidation")
         assertEquals(data["status"], "Ok")
@@ -181,7 +181,7 @@ class EventsTest {
         // Arrange
         val event = JWTValidationEvent(false)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "JWTValidation")
         assertEquals(data["status"], "Failed")
@@ -200,7 +200,7 @@ class EventsTest {
             invalidFieldTypes = emptyList()
         )
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "BeforeSubmit")
         assertEquals(data["status"], "Ok")
@@ -221,7 +221,7 @@ class EventsTest {
             invalidFieldTypes = emptyList()
         )
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "BeforeSubmit")
         assertEquals(data["status"], "Failed")
@@ -242,7 +242,7 @@ class EventsTest {
             invalidFieldTypes = emptyList()
         )
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         val content = data["content"] as ArrayList<*>
         // Assert
         assertEquals(data["type"], "BeforeSubmit")
@@ -261,7 +261,7 @@ class EventsTest {
         val latency = 400L
         val event = ResponseEvent(code, latency, null)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Submit")
         assertEquals(data["status"], "Ok")
@@ -278,7 +278,7 @@ class EventsTest {
         val error = "test"
         val event = ResponseEvent(code, latency, error)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Submit")
         assertEquals(data["status"], "Ok")
@@ -294,7 +294,7 @@ class EventsTest {
         val scannerType = "Test"
         val event = ScanEvent("Ok", scannerType, null)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Scan")
         assertEquals(data["status"], status)
@@ -310,7 +310,7 @@ class EventsTest {
         val scanId = "Test"
         val event = ScanEvent("Ok", scannerType, scanId)
         // Act
-        val data = event.getData(VAULT_ID, FORM_ID, ENVIRONMENT)
+        val data = event.getData(ID, FORM_ID, ENVIRONMENT)
         // Assert
         assertEquals(data["type"], "Scan")
         assertEquals(data["status"], status)


### PR DESCRIPTION
## Feature [ANDROIDSDK-588](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-588)

## Description of changes
 - Rename `VGSCheckoutMultiplexingConfig` `vaultID` property to `tenantId`.
 - Rename `vaultID` to `vaultId` in all other places.
 - Rename `formID` to `formId`.
