### PR TITLE
Added ability to set sub account id

### DIFF
--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutAddCardConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutAddCardConfig.kt
@@ -85,8 +85,6 @@ class VGSCheckoutAddCardConfig internal constructor(
     }
 
     /**
-     * Public constructor.
-     *
      * @param accessToken payment orchestration app access token.
      * @param tenantId unique organization id.
      * @param environment type of vault.
@@ -101,6 +99,7 @@ class VGSCheckoutAddCardConfig internal constructor(
         accessToken: String,
         routeId: String,
         tenantId: String,
+        subAccountId: String?,
         environment: VGSCheckoutEnvironment = VGSCheckoutEnvironment.Sandbox(),
         formConfig: VGSCheckoutFormConfig,
         isScreenshotsAllowed: Boolean = false
@@ -109,7 +108,7 @@ class VGSCheckoutAddCardConfig internal constructor(
         routeId,
         tenantId,
         environment,
-        createRouteConfig(accessToken),
+        createRouteConfig(accessToken, subAccountId),
         formConfig,
         isScreenshotsAllowed,
         true,
@@ -140,6 +139,7 @@ class VGSCheckoutAddCardConfig internal constructor(
         private var isScreenshotsAllowed = false
         private var accessToken = ""
         private var routeId = ORCHESTRATION_URL_ROUTE_ID
+        private var subAccountId: String? = null
         private var isRemoveCardOptionEnabled: Boolean = true
         private var cardIds: List<String> = emptyList()
 
@@ -192,6 +192,15 @@ class VGSCheckoutAddCardConfig internal constructor(
          */
         fun setRouteId(routeId: String) = this.apply {
             this.routeId = routeId
+        }
+
+        /**
+         * Defines sub-account id.
+         *
+         * @param id A sub-account id.
+         */
+        fun setSubAccountId(id: String) = this.apply {
+            this.subAccountId = id
         }
 
         /**
@@ -347,6 +356,7 @@ class VGSCheckoutAddCardConfig internal constructor(
                 accessToken,
                 routeId,
                 tenantId,
+                subAccountId,
                 environment,
                 formConfig,
                 isScreenshotsAllowed

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutPaymentConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/VGSCheckoutPaymentConfig.kt
@@ -101,6 +101,7 @@ internal class VGSCheckoutPaymentConfig internal constructor(
         private var accessToken = ""
         private var orderId = ""
         private var routeId = ORCHESTRATION_URL_ROUTE_ID
+        private var subAccountId: String? = null
         private var cardIds: List<String> = arrayListOf()
         private var isRemoveCardOptionEnabled: Boolean = true
 
@@ -145,6 +146,15 @@ internal class VGSCheckoutPaymentConfig internal constructor(
          */
         fun setRouteId(routeId: String) = this.apply {
             this.routeId = routeId
+        }
+
+        /**
+         * Defines sub-account id.
+         *
+         * @param id A sub-account id.
+         */
+        fun setSubAccountId(id: String) = this.apply {
+            this.subAccountId = id
         }
 
         /**
@@ -325,6 +335,7 @@ internal class VGSCheckoutPaymentConfig internal constructor(
                 accessToken,
                 orderId,
                 routeId,
+                subAccountId,
                 tenantId,
                 VGSCheckoutPaymentMethod.SavedCards(cardIds),
                 environment,
@@ -371,6 +382,7 @@ internal class VGSCheckoutPaymentConfig internal constructor(
             accessToken: String,
             orderId: String,
             routeId: String,
+            subAccountId: String?,
             tenantId: String,
             paymentMethod: VGSCheckoutPaymentMethod.SavedCards,
             environment: VGSCheckoutEnvironment = VGSCheckoutEnvironment.Sandbox(),
@@ -384,7 +396,7 @@ internal class VGSCheckoutPaymentConfig internal constructor(
                 routeId,
                 tenantId,
                 environment,
-                createRouteConfig(accessToken),
+                createRouteConfig(accessToken, subAccountId),
                 formConfig,
                 isScreenshotsAllowed,
                 isRemoveCardOptionEnabled,

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/core/OrchestrationConfig.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/config/core/OrchestrationConfig.kt
@@ -101,7 +101,12 @@ abstract class OrchestrationConfig internal constructor(
         private const val AUTHORIZATION_HEADER_NAME = "Authorization"
         private const val BEARER_TOKEN_TYPE = "Bearer"
 
-        internal fun createRouteConfig(accessToken: String) = VGSCheckoutRouteConfig(
+        private const val KEY_SUB_ACCOUNT_ID = "sub_account_id"
+
+        internal fun createRouteConfig(
+            accessToken: String,
+            subAccountId: String? = null
+        ) = VGSCheckoutRouteConfig(
             PATH,
             VGSCheckoutHostnamePolicy.Vault,
             VGSCheckoutRequestOptions(
@@ -110,7 +115,7 @@ abstract class OrchestrationConfig internal constructor(
                     CONTENT_TYPE_HEADER_NAME to CONTENT_TYPE,
                     AUTHORIZATION_HEADER_NAME to "$BEARER_TOKEN_TYPE $accessToken"
                 ),
-                emptyMap(),
+                if (subAccountId.isNullOrEmpty()) emptyMap() else mapOf(KEY_SUB_ACCOUNT_ID to subAccountId),
                 VGSCheckoutDataMergePolicy.NESTED_JSON
             )
         )

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/networking/command/TransferCommand.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/networking/command/TransferCommand.kt
@@ -3,6 +3,7 @@ package com.verygoodsecurity.vgscheckout.networking.command
 import android.content.Context
 import com.verygoodsecurity.vgscheckout.collect.util.extension.concatWithSlash
 import com.verygoodsecurity.vgscheckout.collect.util.extension.toJSON
+import com.verygoodsecurity.vgscheckout.config.networking.VGSCheckoutRouteConfig
 import com.verygoodsecurity.vgscheckout.exception.VGSCheckoutException
 import com.verygoodsecurity.vgscheckout.networking.client.HttpMethod
 import com.verygoodsecurity.vgscheckout.networking.client.HttpRequest
@@ -39,38 +40,29 @@ internal class TransferCommand constructor(
     private fun createRequest(params: Params) = HttpRequest(
         params.url concatWithSlash PATH,
         generatePayload(params),
-        mapOf(
-            AUTHORIZATION_HEADER_KEY to String.format(
-                AUTHORIZATION_HEADER_VALUE,
-                params.accessToken
-            )
-        ),
+        params.config.requestOptions.extraHeaders,
         HttpMethod.POST
     )
 
     private fun generatePayload(params: Params) =
-        mutableMapOf(
+        (mutableMapOf(
             JSON_KEY_ORDER_ID to params.orderId,
             JSON_KEY_SOURCE to params.source
-        ).toJSON().toString()
+        ) + params.config.requestOptions.extraData).toJSON().toString()
 
     companion object {
-
-        private const val AUTHORIZATION_HEADER_KEY = "Authorization"
-        private const val AUTHORIZATION_HEADER_VALUE = "Bearer %s"
 
         private const val PATH = "transfers"
 
         private const val JSON_KEY_ORDER_ID = "order_id"
         private const val JSON_KEY_SOURCE = "source"
-        private const val JSON_KEY_CURRENCY = "currency"
     }
 
     internal data class Params(
         val url: String,
         val orderId: String,
         val source: String,
-        val accessToken: String
+        val config: VGSCheckoutRouteConfig
     ) : Command.Params()
 
     data class Result constructor(

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/method/TransferPaymentMethodFragment.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/method/TransferPaymentMethodFragment.kt
@@ -18,8 +18,7 @@ internal class TransferPaymentMethodFragment : PaymentMethodFragment<VGSCheckout
                 config.baseUrl,
                 config.order?.id ?: "",
                 card.finId,
-                config.routeConfig.requestOptions.extraHeaders,
-                config.routeConfig.requestOptions.extraData
+                config.routeConfig
             )
         ).execute(::handleTransferResult)
     }

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/method/TransferPaymentMethodFragment.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/method/TransferPaymentMethodFragment.kt
@@ -18,7 +18,8 @@ internal class TransferPaymentMethodFragment : PaymentMethodFragment<VGSCheckout
                 config.baseUrl,
                 config.order?.id ?: "",
                 card.finId,
-                config.accessToken
+                config.routeConfig.requestOptions.extraHeaders,
+                config.routeConfig.requestOptions.extraData
             )
         ).execute(::handleTransferResult)
     }

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/save/SaveAndPayFragment.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/save/SaveAndPayFragment.kt
@@ -22,7 +22,8 @@ internal class SaveAndPayFragment : OrchestrationFragment<VGSCheckoutPaymentConf
                 config.baseUrl,
                 config.order?.id ?: "",
                 source,
-                config.accessToken
+                config.routeConfig.requestOptions.extraHeaders,
+                config.routeConfig.requestOptions.extraData
             )
         ).execute(::handleTransferResult)
     }

--- a/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/save/SaveAndPayFragment.kt
+++ b/vgscheckout/src/main/java/com/verygoodsecurity/vgscheckout/ui/fragment/save/SaveAndPayFragment.kt
@@ -22,8 +22,7 @@ internal class SaveAndPayFragment : OrchestrationFragment<VGSCheckoutPaymentConf
                 config.baseUrl,
                 config.order?.id ?: "",
                 source,
-                config.routeConfig.requestOptions.extraHeaders,
-                config.routeConfig.requestOptions.extraData
+                config.routeConfig
             )
         ).execute(::handleTransferResult)
     }


### PR DESCRIPTION
## Feature [ANDROIDSDK-714]

## Description of changes
- Added ability to set sub-account id into payment config;
-  Added ability to set sub-account id into add config.

## Example
```
VGSCheckoutAddCardConfig.Builder("<VAULT_ID>")
     .setSubAccountId("<SUB_ACCOUNT_ID>")
     .build()
```


[ANDROIDSDK-714]: https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ